### PR TITLE
Update bencode with fixed UTF-8 encoding bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bencode (0.8.0)
+    bencode (0.8.1)
     diff-lcs (1.2.5)
     rack (1.5.2)
     rack-protection (1.5.3)

--- a/spec/feature/scrape_spec.rb
+++ b/spec/feature/scrape_spec.rb
@@ -13,11 +13,9 @@ describe "GET /scrape" do
   end
 
   it "counts properly UTF-8 chars" do
-    pending "waiting for bencode fix to be deployed" do
-      get '/scrape', info_hash: "Amq@\n*c\u001A\xB4\x8D\xBAo\xA6S\xABǌ\u0001\x8D\xBA"
-      expect(last_response).to be_ok
-      expect(response).not_to include('failure reason')
-    end
+    get '/scrape', info_hash: "Amq@\n*c\u001A\xB4\x8D\xBAo\xA6S\xABǌ\u0001\x8D\xBA"
+    expect(last_response).to be_ok
+    expect(response).not_to include('failure reason')
   end
 
   it "returns stats for one hash" do


### PR DESCRIPTION
Ok here is the fix I talked about.
I fixed string encoding in bencode because it was returning the wrong number of chars when some bytes happen to be UTF-8 valid combination, which is often the case in info_hash.
So the scraper was producing invalid bencode document impossible to parse for the client.
